### PR TITLE
JVM-1818: Exclude all subclasses of Throwable.

### DIFF
--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -429,6 +429,14 @@ void PEAState::add_new_allocation(Node* obj) {
       return;
     }
 #endif
+    // Opt out all subclasses of Throwable because C2 will not inline all methods of them including <init>.
+    // PEA needs to materialize it at <init>.
+    ciInstanceKlass* ik = oop_type->is_instptr()->instance_klass();
+    ciEnv* env = ciEnv::current();
+    if (ik->is_subclass_of(env->Throwable_klass())) {
+      return;
+    }
+
     bool result = _state.put(alloc, new VirtualState(nfields));
     assert(result, "the key existed in _state");
     add_alias(alloc, obj);


### PR DESCRIPTION
C2 inliner will not inline methods from the subclasses of Throwable, including `<init>`.

here is a simple Exception object. 
```java
ex = new Exception("ghost");
```
PEA needs to materialize the object immediately at bci 13. It is because C2 inline refuses to inline its constructor. We pass `this` as receiver. it is ArgEscaped. 

```
         7: new           #13                 // class java/lang/Exception
        10: dup
        11: ldc           #15                 // String ghost
        13: invokespecial #17                 // Method java/lang/Exception."<init>":(Ljava/lang/String;)V
```

Even though C2 optimizer will remove the original object, the materialization consumes more memories. We should avoid all objects which are subclasses of Throwable.  This patch opts them out at the beginning.
