### PR TITLE
[PEA] No work when merging virtual phi and virtual input

### DIFF
--- a/PEA/run_merge_all_virts.sh
+++ b/PEA/run_merge_all_virts.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/bash
-java -Xms32M -Xmx32M -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-UseTLAB -XX:CompileCommand=dontinline,MergeAllVirts::blackhole -XX:CompileCommand='compileonly,MergeAllVirts::*' $* MergeAllVirts
+java -Xms32M -Xmx32M -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-UseTLAB -XX:CompileCommand=dontinline,MergeAllVirts::blackhole -XX:CompileCommand='compileonly,MergeAllVirts::*' -Xbatch $* MergeAllVirts

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1856,8 +1856,6 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
                       Node* mv = ensure_object_materialized(m, as, map(), r, block()->init_pnum());
                       phi->replace_edge(m, mv);
                       as.update(id, new EscapedState(phi));
-                    } else {
-                      assert(false, "should be the same oop if they are both virtual");
                     }
                   }
                 }


### PR DESCRIPTION
slowdebug stack trace before this patch
```
(gdb) bt
#0  0x00007ffff5c5233e in Parse::merge_common (this=0x7fffb5974a30, target=0x7fff8016b3f8, pnum=1) at /home/joshcao/jdk/jdk/src/hotspot/share/opto/parse1.cpp:1860
#1  0x00007ffff5c5101f in Parse::merge (this=0x7fffb5974a30, target_bci=430) at /home/joshcao/jdk/jdk/src/hotspot/share/opto/parse1.cpp:1658
#2  0x00007ffff5c50b11 in Parse::do_one_block (this=0x7fffb5974a30) at /home/joshcao/jdk/jdk/src/hotspot/share/opto/parse1.cpp:1579
#3  0x00007ffff5c4cb50 in Parse::do_all_blocks (this=0x7fffb5974a30) at /home/joshcao/jdk/jdk/src/hotspot/share/opto/parse1.cpp:724
#4  0x00007ffff5c4c65b in Parse::Parse (this=0x7fffb5974a30, caller=0x7fff805992a8, parse_method=0x7fff8051d420, expected_uses=1, caller_state=0x0)
    at /home/joshcao/jdk/jdk/src/hotspot/share/opto/parse1.cpp:628
#5  0x00007ffff524b459 in ParseGenerator::generate (this=0x7fff80599288, jvms=0x7fff805992a8) at /home/joshcao/jdk/jdk/src/hotspot/share/opto/callGenerator.cpp:99
#6  0x00007ffff536e1e7 in Compile::Compile (this=0x7fffb59759f0, ci_env=0x7fffb59766f0, target=0x7fff8051d420, osr_bci=-1, options=..., directive=0x7ffff0215780)
    at /home/joshcao/jdk/jdk/src/hotspot/share/opto/compile.cpp:767
#7  0x00007ffff5248443 in C2Compiler::compile_method (this=0x7ffff0331210, env=0x7fffb59766f0, target=0x7fff8051d420, entry_bci=-1, install_code=true, directive=0x7ffff0215780)
    at /home/joshcao/jdk/jdk/src/hotspot/share/opto/c2compiler.cpp:118
#8  0x00007ffff538e902 in CompileBroker::invoke_compiler_on_method (task=0x7ffff03d2b10) at /home/joshcao/jdk/jdk/src/hotspot/share/compiler/compileBroker.cpp:2265
#9  0x00007ffff538d54c in CompileBroker::compiler_thread_loop () at /home/joshcao/jdk/jdk/src/hotspot/share/compiler/compileBroker.cpp:1944
#10 0x00007ffff53afb72 in CompilerThread::thread_entry (thread=0x7ffff0345a50, __the_thread__=0x7ffff0345a50)
    at /home/joshcao/jdk/jdk/src/hotspot/share/compiler/compilerThread.cpp:58
#11 0x00007ffff575d1a3 in JavaThread::thread_main_inner (this=0x7ffff0345a50) at /home/joshcao/jdk/jdk/src/hotspot/share/runtime/javaThread.cpp:717
#12 0x00007ffff575d046 in JavaThread::run (this=0x7ffff0345a50) at /home/joshcao/jdk/jdk/src/hotspot/share/runtime/javaThread.cpp:702
#13 0x00007ffff5f182c4 in Thread::call_run (this=0x7ffff0345a50) at /home/joshcao/jdk/jdk/src/hotspot/share/runtime/thread.cpp:224
#14 0x00007ffff5c0fec2 in thread_native_entry (thread=0x7ffff0345a50) at /home/joshcao/jdk/jdk/src/hotspot/os/linux/os_linux.cpp:740
#15 0x00007ffff779944b in start_thread () from /lib64/libpthread.so.0
#16 0x00007ffff72d052f in clone () from /lib64/libc.so.6
```

7 occurrences in java.base module, including

* [ClassHierarchyResolver.ClassHierarchyInfo::getClassInfo](https://github.com/openjdk/jdk/blob/312702567a15d67fcf69325b9cb6345f9ea026f7/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java#L122)
* [ModulePath::scanDirectory](https://github.com/openjdk/jdk/blob/312702567a15d67fcf69325b9cb6345f9ea026f7/src/java.base/share/classes/jdk/internal/module/ModulePath.java#L269)
* sun.net.NetHooks
* java.util.concurrent.ForkJoinPool
* sun.security.ssl.CertStatusExtension$OCSPStatusRequest
* sun.security.ssl.SignatureScheme
* sun.security.ssl.NamedGroup

---

If I comment out [the assertion](https://github.com/navyxliu/jdk/blob/a2034f493f8555b195fe35b4650a461bdd9340d2/src/hotspot/share/opto/parse1.cpp#L1860), I decrease the number of errors from 61 -> 55. All of the errors are fixed except for `sun.security.ssl.CertStatusExtension$OCSPStatusRequest`, which now produces

```
#  Internal Error (/home/joshcao/jdk/jdk/src/hotspot/share/opto/loopnode.cpp:5959), pid=74957, tid=74970
#  assert(false) failed: Bad graph detected in build_loop_late
#
# JRE version: OpenJDK Runtime Environment (21.0) (fastdebug build 21-internal-adhoc.joshcao.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 21-internal-adhoc.joshcao.jdk, mixed mode, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x11505fb]  PhaseIdealLoop::build_loop_late_post_work(Node*, bool)+0x88b
```

This looks like a separate issue that needs to be investigated.

---

I don't think anything needs to be done here in the `else` block where the assertion is. We have a virtual phi, and the incoming edge we are merge processing is also virtual.

From Stadler's PEA paper:

```
The MergeProcessor also examines every already existing
Phi nodes that is attached to the Merge node. It needs to
look for inputs of the Phi node that are aliased with Ids:
• If all inputs are aliased to the same Id by their aliases
maps, the Phi node will be added as an alias of the Id,
as shown in Figure 6 (c).
• Otherwise, any input that is aliased with a virtual
object needs to be materialized, and the input in the
Phi is replaced with the materialized value.
• If an input is aliased with an escaped object, the input
in the Phi is replaced with the materializedValue.
```

This intuitively makes sense to me. If an input and phi are both virtual, no reason to update anything.