### PR TITLE
Avoid phi(null, n) from materializing.

### DIFF
--- a/PEA/Example2b.java
+++ b/PEA/Example2b.java
@@ -4,7 +4,7 @@ class Example2b {
 
     public String foo(boolean cond) {
         String x = null;
-        
+
         if (cond) {
             x = new String("hello");
         }
@@ -13,15 +13,24 @@ class Example2b {
     }
     public String foo2(boolean cond) {
         String x = null;
-        
+
         if (cond) {
             x = new String("hello");
-            _cache = x;       // object 'x' escapes 
+            _cache = x;       // object 'x' escapes
         }
 
         return x;
     }
 
+    public String foo3(String str, boolean cond) {
+        if (str == null) {
+            str = new String("hello");
+        }
+        if (cond) {
+            _cache = str;
+        }
+        return str;
+    }
     public static void main(String[] args)  {
         Example2b kase = new Example2b();
         int iterations = 0;
@@ -32,11 +41,22 @@ class Example2b {
                 if (s != null && !s.equals("hello")) {
                     throw new RuntimeException("e");
                 }
-                
+
                 kase.foo2(cond);
                 if (kase._cache != null && !kase._cache.equals("hello")) {
                     throw new RuntimeException("e2");
                 }
+
+                if (0 == (iterations % 2)) {
+                    s = kase.foo3(null, cond);
+                } else {
+                    s= kase.foo3(kase._cache, cond);
+                }
+
+                if (s != null && !s.equals("hello")) {
+                    throw new RuntimeException("e3");
+                }
+
                 iterations++;
             }
         } finally {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1880,12 +1880,9 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
             id = pred_as.is_alias(n);
 
             if (id != nullptr) {
-              // case #1: n is live in its block. we need to import it to AS because phi is not top().
-              // references encounter before are constants including nullptr or arguments.
-
-              // current block has not seen id before. it's likely m is null, n is not!
-              // we mark phi=(null, n) as 'Escaped'. or we have 'or we have Bad graph detected'.
-              //
+              // Current block has not seen id before. It's likely t is null, ConP or a global variable.
+              // however, n is tracked in predecessor block. We mark t'= phi(t, n) as 'Escaped', or we would
+              // have 'Bad graph detected'.
               as.update(id, new EscapedState(phi));
               as.add_alias(id, phi);
             }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1883,12 +1883,10 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
               // case #1: n is live in its block. we need to import it to AS because phi is not top().
               // references encounter before are constants including nullptr or arguments.
 
-              ObjectState* pred_os = pred_as.get_object_state(id);
-              if (pred_os->is_virtual()) {
-                as.update(id, pred_os->clone());
-              } else {
-                as.update(id, new EscapedState(phi));
-              }
+              // current block has not seen id before. it's likely m is null, n is not!
+              // we mark phi=(null, n) as 'Escaped'. or we have 'or we have Bad graph detected'.
+              //
+              as.update(id, new EscapedState(phi));
               as.add_alias(id, phi);
             }
           }


### PR DESCRIPTION
based on #25. 

It's possible we merge null value and n.  n is tracked in predecessor's allocation state. 
eg. we need to create a phi(nullptr, new String("helllo")) at line 4. 

```
  0     public String foo3(String str, boolean cond) {
  1         if (str == null) {
  2             str = new String("hello");
  3         }
  4         if (cond) {
  5             _cache = str;
  6         }
  7         return str;
  8     }
```

With PEA, we got bad graph error as follows: 
```
Bad graph detected in build_loop_late
n:  124  LoadUB  === _ 54 123  [[ 128 196 ]]  @java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+17 *, name=hashIsZero, idx=8; #bool !jvms: String::<init> @ bci:30 (line 265) Example2b::foo3 @ bci:10 (line 27)
early(n):   52  Initialize  === 44 1 55 1 1 51 49 108  [[ 53 54 ]]  !jvms: Example2b::foo3 @ bci:4 (line 27)
n->in(1):   54  Proj  === 52  [[ 65 65 65 65 65 124 119 121 128 ]] #2  Memory: @rawptr:BotPTR, idx=Raw; !orig=[131],[64] !jvms: Example2b::foo3 @ bci:4 (line 27)
early(n->in(1)):   52  Initialize  === 44 1 55 1 1 51 49 108  [[ 53 54 ]]  !jvms: Example2b::foo3 @ bci:4 (line 27)
n->in(2):  123  AddP  === _ 59 59 122  [[ 124 ]]   Oop:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+17 * !jvms: String::<init> @ bci:30 (line 265) Example2b::foo3 @ bci:10 (line 27)
early(n->in(2)):    0  Root  === 0 173 227 228  [[ 0 1 3 24 35 36 37 59 168 122 117 106 103 ]] inner
n->in(2)->in(1):   59  ConP  === 0  [[ 123 118 118 123 ]]  #java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact *  Oop:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact *
early(n->in(2)->in(1)):    0  Root  === 0 173 227 228  [[ 0 1 3 24 35 36 37 59 168 122 117 106 103 ]] inner
n->in(2)->in(2):   59  ConP  === 0  [[ 123 118 118 123 ]]  #java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact *  Oop:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact *
early(n->in(2)->in(2)):    0  Root  === 0 173 227 228  [[ 0 1 3 24 35 36 37 59 168 122 117 106 103 ]] inner
n->in(2)->in(3):  122  ConL  === 0  [[ 123 125 197 ]]  #long:17
early(n->in(2)->in(3)):    0  Root  === 0 173 227 228  [[ 0 1 3 24 35 36 37 59 168 122 117 106 103 ]] inner

LCA(n):    5  Parm  === 3  [[ 27 ]] Control !jvms: Example2b::foo3 @ bci:-1 (line 26)
n->out(0):  128  StoreB  === 53 54 125 124  [[ 65 ]]  @java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+17 *, name=hashIsZero, idx=8;  Memory: @java/lang/String (java/io/Serializable,java/lang/Compar
![Example2b_foo3](https://user-images.githubusercontent.com/2386768/233270830-9f49c436-2496-4f10-ac40-3840506afe19.png)
able,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):NotNull:exact+17 *, name=hashIsZero, idx=8; !orig=[134],[64] !jvms: String::<init> @ bci:33 (line 265) Example2b::foo3 @ bci:10 (line 27)
later(n->out(0)):   53  Proj  === 52  [[ 136 56 121 128 ]] #0 !jvms: Example2b::foo3 @ bci:4 (line 27)
n->out(0)->out(0):   65  MergeMem  === _ 1 7 54 54 54 121 54 128 54  [[ 136 ]]  { N54:rawptr:BotPTR N54:java/lang/Object * N54:java/lang/Object+8 * [narrowklass] N121:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+12 * N54:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+16 * N128:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+17 * N54:java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+20 * [narrow] }  Memory: @BotPTR *+bot, idx=Bot; !jvms: Example2b::foo3 @ bci:10 (line 27)
later(n->out(0)->out(0)):   53  Proj  === 52  [[ 136 56 121 128 ]] #0 !jvms: Example2b::foo3 @ bci:4 (line 27)
n->out(1):  196  StoreB  === 164 174 197 124  [[ 177 ]]  @java/lang/String (java/io/Serializable,java/lang/Comparable,java/lang/CharSequence,java/lang/constant/Constable,java/lang/constant/ConstantDesc):exact+17 *, name=hashIsZero, idx=8;  Memory: @rawptr:NotNull, idx=Raw; !orig=195 !jvms: Example2b::foo3 @ bci:20 (line 30)
later(n->out(1)):  164  CatchProj  === 163  [[ 177 185 202 196 ]] #0@bci -1  !jvms: Example2b::foo3 @ bci:20 (line 30)
n->out(1)->out(0):  177  Initialize  === 164 1 180 1 1 176 185 196 202  [[ 178 179 ]]  !jvms: Example2b::foo3 @ bci:20 (line 30)

idoms of early "52 Initialize":
idom[6]:     5  Parm
idom[5]:    27  If
idom[4]:    33  IfFalse
idom[3]:    39  Allocate
idom[2]:    40  Proj
idom[1]:    43  Catch
idom[0]:    44  CatchProj
n:          52  Initialize

idoms of (wrong) LCA "5 Parm":
n:           5  Parm

Real LCA of early "52 Initialize" (idom[6]) and wrong LCA "5 Parm":
   5  Parm  === 3  [[ 27 ]] Control !jvms: Example2b::foo3 @ bci:-1 (line 26)

#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/local/home/xxinliu/Devel/jdk/src/hotspot/share/opto/loopnode.cpp:6063), pid=97758, tid=97776
#  assert(false) failed: Bad graph detected in build_loop_late
#
```
For n = 124, early control is 52, its late control is supposed to be lower than 52 in dominator tree. 

![Example2b_foo3](https://user-images.githubusercontent.com/2386768/233270876-2383442a-4755-49ec-923e-1f35ef968915.png)

Because of materialization, now we have yet another use of 124 -- 196 StoreB. This node initializes the cloned object. This 196 makes the late control to 5 Parm.  The late control now becomes shallower than the early control. The graph is inscheduleable. 

In this patch, we give up this opportunity by marking the resultant phi 'Escaped' in allocation state. PEA doesn't materialize it anymore. 

It's possible to dodge this problem but still keep this opportunity. eg. if we get rid of the original object or at least remove the field nodes for the original object, we are fine.  unfortunately, there is a phase order issue in current C2. This problem only emerge in LoopOpts. however, we reply on IterativeEA to get rid of the orignal allocation.  if the compilation unit contain loops, C2 optimizer will conduct LoopOpts for Unrolling. 






