### PR TITLE
JVM-1874: materialization breaks the trailing barrier in Initializer

### DIFF
--- a/PEA/auto.rb
+++ b/PEA/auto.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 JVM_FLAGS="-XX:+PrintEscapeAnalysis -XX:+PrintEliminateAllocations -XX:+PrintOptoAssembly -Xlog:gc -XX:+DoPartialEscapeAnalysis"
-PROBLEM_LIST = ["run1_generic.sh", "run_EscapeInInitializer.sh", "run_badgraph_volatile.sh"]
+PROBLEM_LIST = ["run1_generic.sh", "run_badgraph_volatile.sh"]
 
 if $0 == __FILE__
   puts  "using #{%x|which java|}"

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -436,8 +436,13 @@ class Parse : public GraphKit {
   void     set_wrote_fields(bool z)   { _wrote_fields = z; }
   Node*    alloc_with_final() const   { return _alloc_with_final; }
   void set_alloc_with_final(Node* n)  {
-    assert((_alloc_with_final == nullptr) || (_alloc_with_final == n), "different init objects?");
-    _alloc_with_final = n;
+    if (DoPartialEscapeAnalysis) {
+      assert((_alloc_with_final == nullptr) || (_alloc_with_final == jvms()->alloc_state().is_alias(n)), "different init objects?");
+      _alloc_with_final = jvms()->alloc_state().is_alias(n);
+    } else {
+      assert((_alloc_with_final == nullptr) || (_alloc_with_final == n), "different init objects?");
+      _alloc_with_final = n;
+    }
   }
 
   Block*             block()    const { return _block; }
@@ -645,6 +650,7 @@ class Parse : public GraphKit {
 
   // Use speculative type to optimize CmpP node
   Node* optimize_cmp_with_klass(Node* c);
+  void emit_trailing_barrier(Node* obj);
 
  public:
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -146,6 +146,8 @@ class PEAState {
     return _state.contains(id);
   }
 
+  Node* get_cooked_obj(ObjID id) const;
+
   void update(ObjID id, ObjectState* os) {
     if (contains(id)) {
       os->ref_cnt(get_object_state(id)->ref_cnt());


### PR DESCRIPTION
c2 emits a trailing barrier at the end of an Initializer when the program needs it . One condition is that the object has at least one final field. java program initializes the final field in Initializer. In C2 IR, the trailing barrier is a MemBarRelease node.

Currently, C2 Parse assumes that there is only one AllocateNode in an Initializer. it's fair enough because the node refers to 'this'. we don't change 'this' in <init>.
however, this assumption doesn't hold anymore when it comes to PEA. it's possible that 'this' escapes in <init> and PEA materializes the object.

In short word, we may end up with multiple copies of AllocateNode. they all need trailing barriers. 

This patch changes the meaning of _alloc_with_final when DoPartialEscapeAnalysis is true.  _alloc_with_final becomes ObjID.  we use recursive to emit barriers for all potential cooked_oop. 