### PR TITLE
JVM-1917: bail out if c2 merges 2 objects with different ObjIDs

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1896,15 +1896,18 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
           ObjID id = as.is_alias(phi);
 
           if (as.contains(id)) {
-            if (pred_as.contains(id)) {
-              // id are in both AS and PRED_AS
+            if (pred_as.is_alias(n) == id) {
+              // mergethe same object but have different allocation states.
               if (!as.get_object_state(id)->is_virtual() && pred_as.get_object_state(id)->is_virtual()) {
                 n = ensure_object_materialized(n, pred_as, newin, r, pnum);
               } else if (as.get_object_state(id)->is_virtual() && !pred_as.get_object_state(id)->is_virtual()) {
                 // TODO: materialize all.
                 assert(false, "not implement yet");
               }
-            } // else part is case #2: n is nullptr in pred_as. Do nothing.
+            } else {
+              // merge a different object, including n = nullptr
+              as.update(id, new EscapedState(phi));
+            }
           } else {
             id = pred_as.is_alias(n);
 

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1897,7 +1897,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
 
           if (as.contains(id)) {
             if (pred_as.is_alias(n) == id) {
-              // mergethe same object but have different allocation states.
+              // merge the same object but have different allocation states.
               if (!as.get_object_state(id)->is_virtual() && pred_as.get_object_state(id)->is_virtual()) {
                 n = ensure_object_materialized(n, pred_as, newin, r, pnum);
               } else if (as.get_object_state(id)->is_virtual() && !pred_as.get_object_state(id)->is_virtual()) {


### PR DESCRIPTION
sun.security.util.CurveDB.add() has bad graph detected with PEA

PEA tracks the object ECFieldF2m at line 7. It materializes the object at line 28. 

```java
  0 private static void add(KnownOIDs o, int type, String sfield,
  1         String a, String b, String x, String y, String n, int h) {
  2     BigInteger p = bi(sfield);
  3     ECField field;
  4     if ((type == P) || (type == PD)) {
  5         field = new ECFieldFp(p);
  6     } else if ((type == B) || (type == BD)) {
  7         field = new ECFieldF2m(p.bitLength() - 1, p); // EC2FieldF2m allocated.
  8     } else {
  9         throw new RuntimeException("Invalid type: " + type);
 10     }
 11
 12     EllipticCurve curve = new EllipticCurve(field, bi(a), bi(b));
 13     ECPoint g = new ECPoint(bi(x), bi(y));
 14
 15     String oid = o.value();
 16     NamedCurve params = new NamedCurve(o, curve, g, bi(n), h);
 17     if (oidMap.put(oid, params) != null) {
 18         throw new RuntimeException("Duplication oid: " + oid);
 19     }
 20
 21     for (String cn : params.getNameAndAliases()) {
 22         if (nameMap.put(cn.toLowerCase(Locale.ENGLISH),
 23                     params) != null) {
 24             throw new RuntimeException("Duplication name: " + cn);
 25         }
 26     }
 27
 28     int len = field.getFieldSize(); // Materialize Object!!!! this is wrong.
 29     if ((type == PD) || (type == BD) || (lengthMap.get(len) == null)) {
 30         // add entry if none present for this field size or if
 31         // the curve is marked as a default curve.
 32         lengthMap.put(len, params);
 33     }
 34 }
```

There are 2 problems in this case. 
1. when we materialize 'field' at line 28, its type is interface Field.  it's not exact type at all. as a result, PEA skips to initialize its fields. 
2. PEA clones the object at shallower position in dominator tree.  its inputs may level-up and have shallower late control than early control. this results in "bad graph".

This patch bails out when we merge two variables which associate with different ObjIDs. eg. 
at line 11, we merge two 'field' variables. one is `ECFieldFp` and the other one is `ECFieldF2m`. They associate with different ObjIDs. 


Please note that this patch also drops out the opportunity if that two types are exactly same. it's not-trivial to materialize field in the escaping point.

```
ECField field;
if (cond) {
  field = new ECFieldFp(p);
} else {
  field = new ECFieldFp(p); 
}

if (flag) {
  _cachedValue = field; 
}
```