### PR TITLE
JVM-1773: [PEA] MergeMemory of Bad graph detected in build_loop_late

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1823,11 +1823,6 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
     bool check_elide_phi = target->is_SEL_backedge(save_block);
     PEAState& pred_as = newin->jvms()->alloc_state();
     PEAState& as = block()->state();
-    AllocationStateMerger as_merger(as);
-    if (DoPartialEscapeAnalysis) {
-      as_merger.merge(pred_as, this, r, pnum);
-    }
-
     for (uint j = 1; j < newin->req(); ++j) {
       Node* m = map()->in(j);   // Current state of target.
       Node* n = newin->in(j);   // Incoming change to target state.
@@ -1933,6 +1928,11 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
         }
       }
     } // End of for all values to be merged
+
+    AllocationStateMerger as_merger(as);
+    if (DoPartialEscapeAnalysis) {
+      as_merger.merge(pred_as, this, r, pnum);
+    }
 
     if (pnum == PhiNode::Input &&
         !r->in(0)) {         // The occasional useless Region

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -169,7 +169,7 @@ class PEAState {
   void add_new_allocation(Node* obj);
   EscapedState* materialize(GraphKit* kit, Node* var);
 
-  void aliases(Unique_Node_List& nodes) const;
+  int objects(Unique_Node_List& nodes) const;
 
   VirtualState* as_virtual(Node* var) const {
     ObjID id = is_alias(var);


### PR DESCRIPTION
This patch merges two allocation states based on the intersection of ObjIDs. 

So far, it's still merge two objects with VirtualState. In the future, we will also handle two objects with different states. we just need to do type coercion to Escaped. 

We also move AllocationStateMerger after merging map(). it's possible that some nodes are live in map() and phi nodes are created there. we leverage the existing phi nodes for them.

When we compile <clinit> below,
```java
    private static final class NFCSingleton {
        private static final Norm2AllModesSingleton INSTANCE=new Norm2AllModesSingleton("nfc");
    }
```

we miss to merge the allocation state for 'this' at line 11. line 6 and 7 may throw 'Throwable' exception and leave allModes null.  if we don't merge allocation state, we will end with bad graph. 

The very reason we didn't merge them because the aliases of Object Norm2AllModesSingleton
are different. that's why we need to merge allocation state based on common ObjIDs.  

```java
  1 private Norm2AllModesSingleton(String name) {
  2     try {
  3         @SuppressWarnings("deprecation")
  4         String DATA_FILE_NAME = "/jdk/internal/icu/impl/data/icudt" +
  5             VersionInfo.ICU_DATA_VERSION_PATH + "/" + name + ".nrm";
  6         NormalizerImpl impl=new NormalizerImpl().load(DATA_FILE_NAME);
  7         allModes=new Norm2AllModes(impl); //  allModes points to 'new Norm2AllModes(impl)'
  8     } catch (RuntimeException e) {
  9         exception=e;                      // allModes points to a phi. 
 10     }
 11 } 
```