### PR TITLE
JVM-1693: Materialization updates AddP which is not dominated by current control

### DIFF
--- a/PEA/auto.rb
+++ b/PEA/auto.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 JVM_FLAGS="-XX:+PrintEscapeAnalysis -XX:+PrintEliminateAllocations -XX:+PrintOptoAssembly -Xlog:gc -XX:+DoPartialEscapeAnalysis"
-PROBLEM_LIST = ["run1_generic.sh", "run_badgraph_volatile.sh"]
+PROBLEM_LIST = ["run1_generic.sh"]
 
 if $0 == __FILE__
   puts  "using #{%x|which java|}"

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -506,37 +506,6 @@ static void replace_in_map(GraphKit* kit, Node* old, Node* neww) {
     if (x == old) {
       map->set_req(i, neww); // safepointNode is not hashashable.
       map->record_replaced_node(old, neww); // flush to caller.
-    } else {
-      if (x->is_DecodeN()) {
-        x = x->in(1);
-        assert(x->Opcode() == Op_LoadN, "sanity check");
-      }
-
-      if (x->is_Load()) {
-        Node* addr = x->in(MemNode::Address);
-        Node_List stack(4);
-
-        while (addr->is_AddP() && addr->in(AddPNode::Base) == old) {
-          stack.push(addr);
-          addr = addr->in(AddPNode::Address);
-        }
-
-        if (stack.size() > 0) {
-          Node* prev = neww;
-          do {
-            addr = stack.pop();
-            prev = gvn.transform(new AddPNode(neww, prev, addr->in(AddPNode::Offset)));
-          } while (stack.size() > 0);
-
-          bool is_in_table = gvn.hash_delete(x);
-          x->set_req(MemNode::Address, prev);
-
-          // TODO: also need to update memory if it's from old object's memory!
-          if (is_in_table) {
-            gvn.hash_find_insert(x);
-          }
-        }
-      } // x->is_Load()
     }
   }
 }


### PR DESCRIPTION
LoadNode is a hashable node, therefore it's possible that multiple regions are sharing with a same LoadNode. if we replace the base address after materialization, it's possible that we use the CheckCastPP before its definition. 

We capture this error in `java.math.BitSieve`. PEA materializes 'this' at line 7. 
however, we generate a LoadINode for limit = this.length at line 2.  we can't replace the base address of this load because it's dominated by the materialization. 

```
  1 private int sieveSearch(int limit, int start) {
  2     if (start >= limit)
  3         return -1;
  4
  5     int index = start;
  6     do {
  7         if (!get(index)) // materialization
  8             return index;
  9         index++;
 10     } while(index < limit-1);
 11     return -1;
 12 }
```

This patch just keeps using the original object. it's fine because we assume all those load nodes will be processed by scalar replacement in the optimizer. 