### PR TITLE
JVM-1916: a Virtual State becomes top after merge

### DIFF
--- a/PEA/MergeEscaped.java
+++ b/PEA/MergeEscaped.java
@@ -105,6 +105,32 @@ class MergeEscaped {
         }
     }
 
+    private static void test4(MergeEscaped obj, int cond) {
+        if (cond == 0) {
+            obj.a = 1;
+        } else if (cond == 1) {
+            obj.a = 2;
+        } else {
+            blackhole(obj);
+        }
+    }
+
+    public static MergeEscaped escaped4(boolean cond1, boolean cond2) {
+        MergeEscaped obj = new MergeEscaped();
+
+        int cond = 0;
+        if (cond1) {
+            cond = 2;  // cond1 << 1
+        }
+        if (cond2) {
+            cond = cond + 1;
+        }
+
+        test4(obj,  cond);
+        blackhole(obj);
+        return obj;
+    }
+
     public static void main(String[] args) {
         long iterations = 0;
 
@@ -121,6 +147,8 @@ class MergeEscaped {
 
                 sum = MergeEscaped.escaped3(cond, cond2).sum();
                 check_result3(cond, cond2, sum);
+
+                escaped4(cond, cond2);
                 iterations++;
             }
         } finally {

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1580,6 +1580,16 @@ Node *AllocateNode::make_ideal_mark(PhaseGVN *phase, Node* obj, Node* control, N
   return mark_node;
 }
 
+// This is a precise notnull oop of the klass.
+// (Actually, it need not be precise if this is a reflective allocation.)
+// It's what we cast the result to.
+const TypeOopPtr* AllocateNode::oop_type(const PhaseTransform& phase) const {
+  Node* klass_node = in(KlassNode);
+  const TypeKlassPtr* tklass = phase.type(klass_node)->isa_klassptr();
+  if (!tklass) tklass = TypeInstKlassPtr::OBJECT;
+  return tklass->as_instance_type();
+}
+
 // Retrieve the length from the AllocateArrayNode. Narrow the type with a
 // CastII, if appropriate.  If we are not allowed to create new nodes, and
 // a CastII is appropriate, return null.

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -975,6 +975,8 @@ public:
   bool is_allocation_MemBar_redundant() { return _is_allocation_MemBar_redundant; }
 
   Node* make_ideal_mark(PhaseGVN *phase, Node* obj, Node* control, Node* mem);
+
+  const TypeOopPtr* oop_type(const PhaseTransform& phase) const;
 };
 
 //------------------------------AllocateArray---------------------------------

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1051,7 +1051,7 @@ void Parse::do_exits() {
     } else if (alloc_with_final() != nullptr) {
       PEAState& as = jvms()->alloc_state();
       // in PEA, alloc_with_final stores ObjID
-      Node* obj = as.get_cooked_obj((ObjID)alloc_with_final());
+      Node* obj = as.get_cooked_oop((ObjID)alloc_with_final());
       emit_trailing_barrier(obj);
     }
     if (PrintOpto && (Verbose || WizardMode)) {
@@ -1823,6 +1823,8 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
     bool check_elide_phi = target->is_SEL_backedge(save_block);
     PEAState& pred_as = newin->jvms()->alloc_state();
     PEAState& as = block()->state();
+    AllocationStateMerger as_merger(as);
+
     for (uint j = 1; j < newin->req(); ++j) {
       Node* m = map()->in(j);   // Current state of target.
       Node* n = newin->in(j);   // Incoming change to target state.
@@ -1933,7 +1935,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       }
     } // End of for all values to be merged
 
-    AllocationStateMerger as_merger(as);
+
     if (DoPartialEscapeAnalysis) {
       as_merger.merge(pred_as, this, r, pnum);
     }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1867,7 +1867,6 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
 
                   if (id == pred_as.is_alias(n) && !((pred_os = pred_as.get_object_state(id))->is_virtual())) { // n is escaped.
                     // materialize 'm' because it has been materialized in save_block.
-                    assert(pred_os->get_materialized_value() == n, "sanity: materialized value in save_block is n");
                     Node* mv = ensure_object_materialized(m, as, map(), r, block()->init_pnum());
                     phi->replace_edge(m, mv);
                     as.update(id, new EscapedState(phi));

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -709,7 +709,7 @@ void AllocationStateMerger::merge(const PEAState& newin, GraphKit* kit, RegionNo
       Node* m = _state.get_cooked_oop(obj);
       Node* n = newin.get_cooked_oop(obj);
       if (m->is_Phi() && m->in(0) == region) {
-        assert(m->in(pnum) == nullptr || m->in(pnum) == n, "wrong value is found at phi->pnum");
+        // only update the pnum that we have never seen before.
         if (m->in(pnum) == nullptr) {
           m->set_req(pnum, n);
         }
@@ -717,8 +717,8 @@ void AllocationStateMerger::merge(const PEAState& newin, GraphKit* kit, RegionNo
         const Type* type = obj->oop_type(kit->gvn());
         Node* phi = PhiNode::make(region, m, type);
         phi->set_req(pnum, n);
-        _state.remove_alias(obj, m);
         if (os1->is_virtual()) {
+          _state.remove_alias(obj, m);
           _state.update(obj, new EscapedState(phi));
         } else {
           static_cast<EscapedState*>(os1)->set_materialized_value(phi);

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -108,6 +108,7 @@ class EscapedState: public ObjectState {
     return new EscapedState(_materialized);
   }
   ObjectState& merge(ObjectState* newin, GraphKit* kit, RegionNode* region, int pnum) override {
+    assert(0, "not implemented");
     return *this;
   }
 };
@@ -146,7 +147,7 @@ class PEAState {
     return _state.contains(id);
   }
 
-  Node* get_cooked_obj(ObjID id) const;
+  Node* get_cooked_oop(ObjID id) const;
 
   void update(ObjID id, ObjectState* os) {
     if (contains(id)) {


### PR DESCRIPTION
This patch merges allocation state after merging map(). There are 2 reasons:

1. some variables are not live after merging point. We still need to merge their allocation states because caller may still use them. 

2. we need to merge objects with different states. Prior this patch, we only merge two virtual objects.  this patch also merges the following 3 cases: 1) virtual/escaped 2) escaped/virtual and 3) escaped/escaped. 