### PR TITLE
[PEA] print PEA statistics

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -95,6 +95,10 @@ void Parse::print_statistics() {
   if (PrintParseStatistics && BytecodeParseHistogram::initialized()) {
     BytecodeParseHistogram::print();
   }
+
+  if (DoPartialEscapeAnalysis) {
+    printPeaStatistics();
+  }
 }
 #endif
 

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -204,4 +204,6 @@ class AllocationStateMerger {
   void merge(const PEAState& newin, GraphKit* kit, RegionNode* region, int pnum);
   void process_phi(PhiNode* phi, Node* old);
 };
+
+void printPeaStatistics();
 #endif // SHARE_OPTO_PARTIAL_ESCAPE_HPP


### PR DESCRIPTION
Print statistics for number of allocations PEA is tracking, and number of materializations. Not exactly sure what statistics we want now, but this is a starting point.

Example output:

```
Epsilon Test: 30000
--- Compiler Statistics ---
Methods seen: 14  Methods parsed: 14  Nodes created: 4668
Blocks parsed: 69  Blocks seen: 69
24 original null checks - 21 elided (87%); optimizer leaves 20,
0 made implicit ( 0%)
PEA: num allocations tracked = 3, num materializations = 3
StringConcat:    0/   0/   0(replaced/merged/total)
CCP: 6  constants found: 0
Total frameslots = 32, Max frameslots = 4
Inserted 0 spill loads, 0 spill stores, 0 mem-mem moves and 0 copies.
Total load cost=      0, store cost =      0, mem-mem cost =  0.00, copy cost =     0.
Adjusted spill cost =       0.
Conservatively coalesced 66 copies, 0 pairs, 8 post alloc.
Average allocation trips 1.086957
High Pressure Blocks = 100, Low Pressure Blocks = 277
Nops added 0 bytes to total of 3511 bytes, for 0.00%
Peephole: peephole rules applied: 0
PhaseIdealLoop=23, sum _unique=6935, long loops=0/0/0
No escape = 3, Arg escape = 0, Global escape = 3
Objects scalar replaced = 3, Monitor objects removed = 0, GC barriers removed = 0, Memory barriers removed = 3
```