### PR TITLE
[PEA] Clear allocation state before late inlines

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -648,6 +648,9 @@ void CallGenerator::do_late_inline_helper() {
       map->init_req(i1, call->in(i1));
     }
 
+    // Clear the allocation state. We assume all inputs are materialized.
+    jvms->alloc_state().clear();
+
     // Make sure the state is a MergeMem for parsing.
     if (!map->in(TypeFunc::Memory)->is_MergeMem()) {
       Node* mem = MergeMemNode::make(map->in(TypeFunc::Memory));

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -642,14 +642,15 @@ void CallGenerator::do_late_inline_helper() {
     // Make a clone of the JVMState that appropriate to use for driving a parse
     JVMState* old_jvms = call->jvms();
     JVMState* jvms = old_jvms->clone_shallow(C);
+
+    // Clear the allocation state. We assume all inputs are materialized.
+    jvms->alloc_state().clear();
+
     uint size = call->req();
     SafePointNode* map = new SafePointNode(size, jvms);
     for (uint i1 = 0; i1 < size; i1++) {
       map->init_req(i1, call->in(i1));
     }
-
-    // Clear the allocation state. We assume all inputs are materialized.
-    jvms->alloc_state().clear();
 
     // Make sure the state is a MergeMem for parsing.
     if (!map->in(TypeFunc::Memory)->is_MergeMem()) {

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -653,8 +653,12 @@ void Parse::do_call() {
   if (DoPartialEscapeAnalysis) {
     if (cg->is_inline()) {
       static_cast<InlineCallGenerator* >(cg)->set_caller_state(&block()->state());
-    } else { // TODO: what about late inline?
+    } else {
       PEAState& state = jvms->alloc_state();
+      // Materialize all inputs to non-inline and late inline calls.
+      // TODO: we can support late inline calls if we can pass the right JVM
+      // state to the late inline call.
+      //
       // TODO: Should we query BCEA to make an enger inlining decision here?
       // Because callee require a concrete object pointer as an argument,
       // we have nothing to do but matertialize it.

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -491,8 +491,7 @@ void PEAState::add_new_allocation(Node* obj) {
 
 PEAState& PEAState::operator=(const PEAState& init) {
   if (this != &init) {
-    _state.unlink_all();
-    _alias.unlink_all();
+    clear();
 
     init._state.iterate([&](ObjID key, ObjectState* value) {
       _state.put(key, value->clone());

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -186,6 +186,11 @@ class PEAState {
     return nullptr;
   }
 
+  void clear() {
+    _state.unlink_all();
+    _alias.unlink_all();
+  }
+
   void materialize_all();
 
 #ifndef PRODUCT


### PR DESCRIPTION
We get a faulty allocation state in late inline calls. This patch fixes this by clearing allocation state for inlining.

This reduces failures from 16->13.

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
>> jtreg:test/hotspot/jtreg:tier1                     2178  2158    13     7 <<
==============================
```