### PR TITLE
[PEA] paranoid test for re-allocating an object at merge point

### DIFF
--- a/PEA/MergeIfElseParanoid.java
+++ b/PEA/MergeIfElseParanoid.java
@@ -1,0 +1,26 @@
+class MergeIfElseParanoid {
+    static class Node {
+       public Node _next;
+       public Node() {}
+    }
+
+    static Object _global;
+    static Object _global2;
+
+    public static void test(boolean cond) {
+        Object foo = new Object();
+        if (cond) {
+            _global = foo;
+        }
+        // When `cond == true`, we materialize foo a second time. We cannot
+        // eliminate the original allocation because we need for when
+        // `cond == false`.
+        _global2 = foo;
+    }
+
+    public static void main(String[] args ) {
+        for (int i=0; i < 100_000; ++i) {
+            test(0 == (i& 0xf));
+        }
+    }
+}

--- a/PEA/MergeIfElseParanoid.java
+++ b/PEA/MergeIfElseParanoid.java
@@ -15,6 +15,9 @@ class MergeIfElseParanoid {
         // When `cond == true`, we materialize foo a second time. We cannot
         // eliminate the original allocation because we need for when
         // `cond == false`.
+        //
+        // If we have passive materialization, we would materialize foo in the
+        // predecessor, and the original object would be dead.
         _global2 = foo;
     }
 

--- a/PEA/auto.rb
+++ b/PEA/auto.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 JVM_FLAGS="-XX:+PrintEscapeAnalysis -XX:+PrintEliminateAllocations -XX:-PrintOptoAssembly -Xlog:gc -XX:+PrintOptoStatistics -XX:+DoPartialEscapeAnalysis"
-PROBLEM_LIST = ["run_composite.sh"]
+PROBLEM_LIST = ["run_composite.sh", "run_merge_if_else_paranoid.sh"]
 
 if $0 == __FILE__
   puts  "using #{%x|which java|}"

--- a/PEA/run_merge_if_else_paranoid.sh
+++ b/PEA/run_merge_if_else_paranoid.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -XX:CompileCommand=compileonly,MergeIfElseParanoid::test -XX:-TieredCompilation -Xbatch -XX:+UnlockExperimentalVMOptions -XX:+PEAParanoid $* MergeIfElseParanoid


### PR DESCRIPTION
```
// When `cond == true`, we materialize foo a second time. We cannot
// eliminate the original allocation because we need for when
// `cond == false`.
```

```
dev-dsk-joshcao-2b-df0d3645 [home/joshcao/jdk/jdk/PEA]$ bash run_merge_if_else_paranoid.sh -XX:+DoPartialEscapeAnalysis -XX:+PEAVerbose
CompileCommand: compileonly MergeIfElseParanoid.test bool compileonly = true
MergeIfElseParanoid test (Z)V start tracking 0 | obj#25
 25  Allocate  === 5 6 7 8 1 (23 21 22 1 1 10 1 ) [[ 26 27 28 35 36 37 ]]  rawptr:NotNull ( int:>=0, java/lang/Object:NotNull *, bool, top, bool ) MergeIfElseParanoid::test @ bci:0 (line 11) !jvms: MergeIfElseParanoid::test @ bci:0 (line 11)
PEAState:
Obj#25(Virt) ref = 1 aliases = [42, ]
Virt = 0x7f887c075130
   0 | Obj25    V
PEAState:
Obj#25(Virt) ref = 1 aliases = [42, ]
Virt = 0x7f887c0756f8
PEA materializes a virtual 0 obj25
ciInstanceKlass: java/lang/Object
new object:  110  CheckCastPP  === 107 105  [[ ]]  #java/lang/Object:NotNull:exact *  Oop:java/lang/Object:NotNull:exact * !jvms: MergeIfElseParanoid::test @ bci:13 (line 13)
PEAState:
Obj#25(Mat) ref = 1 aliases = [275, ]
   0 | Obj25    M
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/joshcao/jdk/jdk/src/hotspot/share/opto/macro.cpp:1264), pid=81519, tid=81532
#  fatal error: [PEA] Expanding obj#25 which has been materialized.
#
# JRE version: OpenJDK Runtime Environment (22.0) (fastdebug build 22-internal-adhoc.joshcao.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 22-internal-adhoc.joshcao.jdk, mixed mode, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x1193c03]  PhaseMacroExpand::expand_allocate_common(AllocateNode*, Node*, TypeFunc const*, unsigned char*, Node*)+0xd83
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /local/home/joshcao/jdk/jdk/PEA/hs_err_pid81519.log
[2.342s][warning][os] Loading hsdis library failed
#
# Compiler replay data is saved as:
# /local/home/joshcao/jdk/jdk/PEA/replay_pid81519.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
run_merge_if_else_paranoid.sh: line 2: 81519 Aborted                 java -XX:CompileCommand=compileonly,MergeIfElseParanoid::test -XX:-TieredCompilation -Xbatch -XX:+UnlockExperimentalVMOptions -XX:+PEAParanoid $* MergeIfElseParanoid
```