### PR TITLE
[PEA] add hotspot tier2 target

### DIFF
--- a/PEA/Makefile
+++ b/PEA/Makefile
@@ -11,6 +11,7 @@ empty :=
 space := $(empty) $(empty)
 # CTWRunner accepts arguments with commas instead of spaces
 CTW_RUNNER_JAVA_OPTIONS := $(subst $(space),$(comma),$(CTW_JAVA_OPTIONS))
+JTREG_COMMON := CONF=linux-x86_64-server-fastdebug  JTREG="JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+DoPartialEscapeAnalysis"
 
 set_jdk:
 	if [ -e ${JAVA_PATH} ]; then \
@@ -44,7 +45,10 @@ bootstrap-version: set_jdk
 	java -Xcomp -XX:-TieredCompilation -XX:CICompilerCount=1 -Xbatch -XX:+UnlockExperimentalVMOptions -XX:+DoPartialEscapeAnalysis -XX:-PrintCompilation -version
 
 hotspot-tier1:
-	cd ..; make test TEST="hotspot:tier1"  CONF=linux-x86_64-server-fastdebug  JTREG="JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+DoPartialEscapeAnalysis"
+	cd ..; make test TEST="hotspot:tier1" ${JTREG_COMMON}
+
+hotspot-tier2:
+	cd ..; make test TEST="hotspot:tier2" ${JTREG_COMMON}
 
 all: smoketest bootstrap-version
 


### PR DESCRIPTION
I have three failures on my first one. I believe the second test is flaky in general and the failure is not caused by PEA.

```
compiler/stringopts/TestSideEffectBeforeConstructor.java: Test correctness of the string concatenation optimization with a store between StringBuffer allocation and constructor invocation.
gc/shenandoah/TestAllocIntArrays.java#aggressive: Acceptance tests: collector can withstand allocation
runtime/Metaspace/FragmentMetaspace.java:
```