### PR TITLE
[PEA] Change PEAMethodOnly to be a compile command

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -74,6 +74,7 @@ NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase)) \
     cflags(Vectorize,               bool, false, Vectorize) \
     cflags(CloneMapDebug,           bool, false, CloneMapDebug) \
 NOT_PRODUCT(cflags(IGVPrintLevel,       intx, PrintIdealGraphLevel, IGVPrintLevel)) \
+NOT_PRODUCT(cflags(PEAMethodOnly,       bool, false, PEAMethodOnly)) \
     cflags(VectorizeDebug,          uintx, 0, VectorizeDebug) \
     cflags(IncrementalInlineForceCleanup, bool, IncrementalInlineForceCleanup, IncrementalInlineForceCleanup) \
     cflags(MaxNodeLimit,            intx, MaxNodeLimit, MaxNodeLimit)

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -96,6 +96,7 @@ NOT_PRODUCT(option(TestOptionBool2,  "TestOptionBool2",  Bool)) \
 NOT_PRODUCT(option(TestOptionStr,    "TestOptionStr",    Ccstr)) \
 NOT_PRODUCT(option(TestOptionList,   "TestOptionList",   Ccstrlist)) \
 NOT_PRODUCT(option(TestOptionDouble, "TestOptionDouble", Double)) \
+NOT_PRODUCT(option(PEAMethodOnly, "PEAMethodOnly", Bool)) \
   option(Option, "option", Unknown) \
   option(Unknown, "unknown", Unknown)
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -698,6 +698,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
   }
   set_print_inlining(directive->PrintInliningOption || PrintOptoInlining);
   set_print_intrinsics(directive->PrintIntrinsicsOption);
+  set_pea_method_only(directive->PEAMethodOnlyOption);
   set_has_irreducible_loop(true); // conservative until build_loop_tree() reset it
 
   if (ProfileTraps RTM_OPT_ONLY( || UseRTMLocking )) {

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -342,6 +342,7 @@ class Compile : public Phase {
   uint                  _igv_idx;               // Counter for IGV node identifiers
   bool                  _trace_opto_output;
   bool                  _parsed_irreducible_loop; // True if ciTypeFlow detected irreducible loops during parsing
+  bool                  _pea_method_only; // True if we should run PEA
 #endif
   bool                  _has_irreducible_loop;  // Found irreducible loops
   // JSR 292
@@ -664,6 +665,8 @@ private:
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
   bool              has_monitors() const         { return _has_monitors; }
   void          set_has_monitors(bool v)         { _has_monitors = v; }
+  bool              has_pea_method_only() const  { return _pea_method_only; }
+  void          set_pea_method_only(bool v)      { _pea_method_only = v; }
 
   // check the CompilerOracle for special behaviours for this compile
   bool          method_has_option(enum CompileCommand option) {

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -338,7 +338,6 @@ private:
 
   NONCOPYABLE(PEAContext);
 public:
-  bool match(ciMethod* method) const;
   // mayer's singleton.
   static PEAContext& instance() {
     static PEAContext s;
@@ -523,7 +522,7 @@ void PEAState::add_new_allocation(GraphKit* kit, Node* obj) {
     }
 
     ciMethod* method = kit->jvms()->method();
-    if (PEAContext::instance().match(method)) {
+    if (kit->C->has_pea_method_only()) {
 #ifndef PRODUCT
       if (PEAVerbose) {
         if (method != nullptr) {
@@ -988,15 +987,6 @@ void AllocationStateMerger::merge_at_phi_creation(const PartialEscapeAnalysis* p
 }
 
 AllocationStateMerger::~AllocationStateMerger() {
-}
-
-bool PEAContext::match(ciMethod* method) const {
-  if (_matcher != nullptr && method != nullptr) {
-    VM_ENTRY_MARK;
-    methodHandle mh(THREAD, method->get_Method());
-    return _matcher->match(mh);
-  }
-  return true;
 }
 
 EscapedState* PEAState::escape(ObjID id, Node* p, bool materialized) {


### PR DESCRIPTION
This allows us to specify multiple method patterns for PEA to operate on.

I also suspect that the compile command string pattern matcher is more powerful. I am looking into failure tier2 test
runtime/Metaspace/FragmentMetaspace.java. I cannot trigger the bug with
```
-XX:PEAMethodOnly="com.sun.tools.javac.code.Symtab*::*"
```
But I can trigger it with
```
-XX:CompileCommand="PEAMethodOnly,com.sun.tools.javac.code.Symtab*::*"
```