### PR TITLE
[PEA] Fix typo in run_load_self_into_field.sh

### DIFF
--- a/PEA/run_load_self_into_field.sh
+++ b/PEA/run_load_self_into_field.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/bash
-java -ea -Xcomp -Xms32M -Xmx32M -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-UseOnStackReplacement -XX:+UseTLAB -XX:CompileCommand='compileOnly,LoadIntoSelf.test*' $* LoadSelfIntoField
+java -ea -Xcomp -Xms32M -Xmx32M -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-UseOnStackReplacement -XX:+UseTLAB -XX:CompileCommand='compileOnly,LoadSelfIntoField.test*' $* LoadSelfIntoField


### PR DESCRIPTION
Can confirm that PEA is actually running now with

```
bash run_load_self_into_field.sh -XX:+DoPartialEscapeAnalysis -XX:+PEAVerbose
```