### PR TITLE
[PEA] At loop header, only mark objects that are not live as escaped

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -737,7 +737,7 @@ void Parse::do_all_blocks() {
 
         if (DoPartialEscapeAnalysis && block->is_loop_head()) {
           PEAState& as = jvms()->alloc_state();
-          as.mark_all_escaped();
+          as.mark_all_live_objects_escaped(PEA(), block->start_map());
         }
       }
 

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -736,7 +736,6 @@ void Parse::do_all_blocks() {
         set_map(clone_map());
 
         if (DoPartialEscapeAnalysis && block->is_loop_head()) {
-          kill_dead_locals();
           PEAState& as = jvms()->alloc_state();
           as.mark_all_live_objects_escaped(PEA(), block->start_map());
         }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -736,6 +736,7 @@ void Parse::do_all_blocks() {
         set_map(clone_map());
 
         if (DoPartialEscapeAnalysis && block->is_loop_head()) {
+          kill_dead_locals();
           PEAState& as = jvms()->alloc_state();
           as.mark_all_live_objects_escaped(PEA(), block->start_map());
         }

--- a/src/hotspot/share/opto/partialEscape.hpp
+++ b/src/hotspot/share/opto/partialEscape.hpp
@@ -310,7 +310,8 @@ class PEAState {
   }
 
   // we drop out all virtual objects when we encounter a loop header.
-  void mark_all_escaped();
+  void mark_all_escaped(PartialEscapeAnalysis* pea, ObjID id, Node *obj);
+  void mark_all_live_objects_escaped(PartialEscapeAnalysis *pea, SafePointNode* map);
 
 #ifndef PRODUCT
   void print_on(outputStream* os) const;

--- a/test/micro/org/openjdk/bench/vm/compiler/pea/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/pea/HashMapBench.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler.pea;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 3)
+public class HashMapBench {
+    @Param("100000")
+    private int size;
+
+    @Param("2")
+    private int fillInterval;
+
+    HashMap<Integer, Object> map;
+
+    @Setup
+    public void setUp() {
+        map = new HashMap<>();
+        for (int i = 0; i < size; i += fillInterval) {
+            map.put(i, new Object());
+        }
+    }
+
+    @Benchmark
+    public void replace() {
+        for (int i = 0; i < size; ++i) {
+            map.replace(i, new Object());
+        }
+    }
+}
+

--- a/test/micro/org/openjdk/bench/vm/compiler/pea/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/pea/HashMapBench.java
@@ -36,6 +36,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -45,26 +46,31 @@ import java.util.HashMap;
 @State(Scope.Benchmark)
 @Fork(value = 3)
 public class HashMapBench {
-    @Param("100000")
+    @Param("1024")
     private int size;
 
-    @Param("2")
+    @Param({"1", "2", "4"})
     private int fillInterval;
 
+    ArrayList<Integer> keys;
     HashMap<Integer, Object> map;
 
     @Setup
     public void setUp() {
+        keys = new ArrayList<>();
         map = new HashMap<>();
-        for (int i = 0; i < size; i += fillInterval) {
-            map.put(i, new Object());
+        for (int i = 0; i < size; ++i) {
+            keys.add(i);
+            if (i % fillInterval == 0) {
+                map.put(i, new Object());
+            }
         }
     }
 
     @Benchmark
     public void replace() {
         for (int i = 0; i < size; ++i) {
-            map.replace(i, new Object());
+            map.replace(keys.get(i), new Object());
         }
     }
 }


### PR DESCRIPTION
Escape all objects that are not live at loop header. Before we conservatively escape everything. We can strengthen the optimization by only escaping objects that are live at the loop header. We need to mark objects escaped through DFS. It is possible that an object is live, but it has a reference that is not live. That reference is also escaped.

For example, if we inline [HashMap::replace()](https://github.com/openjdk/jdk/blob/009f5e1fa177eea326aefec0f995f589a01169d2/src/java.base/share/classes/java/util/HashMap.java#L1173-L1182), and the value is an object type, i.e. `HashMap<Integer, Object>`, we don’t need the allocate the object is the key is not present. However, if `HashMap::getNode` is inlined, PEA will encounter [a loop](https://github.com/openjdk/jdk/blob/009f5e1fa177eea326aefec0f995f589a01169d2/src/java.base/share/classes/java/util/HashMap.java#L583-L587), and escape everything. `HashMap::getNode` has nothing to do with the value object, and that object is not live at the loop header. With this patch, we can avoid materializing the value object.

If we set `-p fillInterval=1`, PEA does not have any benefits. All objects are used in `HashMap::replace` because the key is present in the HashMap. With the default `-p fillInterval=2`, we avoid the allocation of the object half of the time, since the key is not present and the new object is not needed. PEA reduces 25% allocation rate with default parameters.
Without PEA:
```
Benchmark                                (fillInterval)  (size)  Mode  Cnt        Score         Error   Units
HashMapBench.replace                                  2  100000  avgt   10  3051607.127 ± 1713433.504   ns/op
HashMapBench.replace:gc.alloc.rate                    2  100000  avgt   10     1121.073 ±     585.919  MB/sec
HashMapBench.replace:gc.alloc.rate.norm               2  100000  avgt   10  3197973.058 ±      11.867    B/op
HashMapBench.replace:gc.count                         2  100000  avgt   10        4.000                counts
HashMapBench.replace:gc.time                          2  100000  avgt   10      726.000                    ms
```
With PEA:
```
Benchmark                                (fillInterval)  (size)  Mode  Cnt        Score        Error   Units
HashMapBench.replace                                  2  100000  avgt   10  2624624.627 ± 808835.461   ns/op
HashMapBench.replace:gc.alloc.rate                    2  100000  avgt   10      907.745 ±    319.824  MB/sec
HashMapBench.replace:gc.alloc.rate.norm               2  100000  avgt   10  2397969.855 ±      6.001    B/op
HashMapBench.replace:gc.count                         2  100000  avgt   10        4.000               counts
HashMapBench.replace:gc.time                          2  100000  avgt   10      660.000                   ms
```